### PR TITLE
fix mstring fn.regex, preserving whitespace, allowing for indented lines, including the closing ***/ token

### DIFF
--- a/mstring.js
+++ b/mstring.js
@@ -1,27 +1,32 @@
 /* Copyright (c) 2012 Richard Rodger */
 
-var errmsg = "mstring: required format is function (){/*** ... ***/}, this is invalid: "
+var errmsg = "mstring: required format is function (){/*** ... ***/}, this is invalid: ";
 
 module.exports = function(f){
   if( !_.isFunction(f) ) {
     throw new Error(errmsg+f)
   }
 
-  var fs = f.toString()
-  var m  = fs.match(/^function\s*\(\)\s*\{\s*\/\*\*\*\n*([\s\S]*)\n*\*\*\*\/\s*\}$/);
-  
+  // allow for whitespace-indented lines
+  var lines = f.toString().split('\n');
+  for (var i = 0; i < lines.length; ++i) {
+    lines[i] = lines[i].replace(/^\s+|\s+$/g, '');
+  }
+
+  var fs = lines.join('\n');
+  var m  = fs.match(/^function\s*\(\)\s*\{\s*\/\*\*\*\n([\s\S]*)\n\*\*\*\/\s*\}$/) 
+
   if( m && _.isString(m[1]) ) {
     return m[1]
   }
-  else throw new Error(errmsg+f);
+  else throw new Error(errmsg+f)
 }
 
 
-var _ = {}
+var _ = {};
 _.isFunction = function(obj) {
-  return !!(obj && obj.constructor && obj.call && obj.apply);
-};
+  return !!(obj && obj.constructor && obj.call && obj.apply)
+}
 _.isString = function(obj) {
-  return !!(obj === '' || (obj && obj.charCodeAt && obj.substr));
-};
-
+  return !!(obj === '' || (obj && obj.charCodeAt && obj.substr))
+}

--- a/mstring.js
+++ b/mstring.js
@@ -7,21 +7,14 @@ module.exports = function(f){
     throw new Error(errmsg+f)
   }
 
-  // allow for whitespace-indented lines
-  var lines = f.toString().split('\n');
-  for (var i = 0; i < lines.length; ++i) {
-    lines[i] = lines[i].replace(/^\s+|\s+$/g, '');
-  }
-
-  var fs = lines.join('\n');
-  var m  = fs.match(/^function\s*\(\)\s*\{\s*\/\*\*\*\n([\s\S]*)\n\*\*\*\/\s*\}$/) 
+  var fs = f.toString();
+  var m  = fs.match(/^function\s*\(\)\s*\{\s*\/\*\*\*\n([\s\S]*)\n(\s*)\*\*\*\/\s*\}$/) 
 
   if( m && _.isString(m[1]) ) {
     return m[1]
   }
   else throw new Error(errmsg+f)
 }
-
 
 var _ = {};
 _.isFunction = function(obj) {

--- a/test.js
+++ b/test.js
@@ -4,62 +4,88 @@ var assert = require('assert')
 var M = require('./mstring')
 
 var a_b = {
-
-  a:
-M(function(){/***
+    a: M(function(){/***
 a
 b
-***/})
-
-  ,b:
-M(function(){
+***/}),
+    b: M(function(){
 /***
 a
 b
-***/
-})
-
-}
-
+***/})
+};
 
 var _a_b_ = {
-
-  a:
-M(function(){/***
+  a: M(function(){/***
 
 a
 b
 
-***/})
-
-  ,b:
-M(function(){
+***/}),
+  b: M(function(){
 /***
 
 a
 b
 
-***/
-})
+***/})
+};
 
-}
+var indented = {
+    a: M(function(){/***
+        a
+        b
+        ***/}),
+    b: M(function(){
+        /***
+        a
+        b
+        ***/})
+};
 
+var blankline_indented = {
+    a: M(function(){/***
+        
+        a
+        b
+        
+        ***/}),
+    b: M(function(){
+        /***
+        
+        a
+        b
+        
+        ***/})
+};
 
-for( var t in a_b ) {
-  assert.equal("a\nb",a_b[t])
-}
+!(function() {
 
-for( var t in _a_b_ ) {
-  assert.equal("\na\nb\n",_a_b_[t])
-}
+    for( var t in a_b ) {
+      assert.equal("a\nb", a_b[t]);
+    }
 
-
-try {
-  var f = function(){}
-  M(f)
-  assert.fail()
-}
-catch(e) { 
-  if( 'AssertionError'==e.name ) throw e; 
-  assert.equal('Error: mstring: required format is function (){/*** ... ***/}, this is invalid: function (){}',e.toString())
-}
+    for( var t in _a_b_ ) {
+      assert.equal("\na\nb\n", _a_b_[t]);
+    }
+    
+    var pad8 = '        ';
+    
+    for( var t in indented ) {
+      assert.equal(pad8 + "a\n" + pad8 + "b", indented[t]);
+    }
+    
+    for( var t in blankline_indented ) {   
+      assert.equal(pad8 + "\n" + pad8 + "a\n" + pad8 + "b\n" + pad8, blankline_indented[t]);
+    }
+    
+    try {
+      var f = function(){}
+      M(f);
+      assert.fail();
+    }
+    catch(e) { 
+      if( 'AssertionError'==e.name ) throw e; 
+      assert.equal('Error: mstring: required format is function (){/*** ... ***/}, this is invalid: function (){}',e.toString());
+    }
+}());


### PR DESCRIPTION
test.js is heavily re-formated ~ includes new indent and blankline + indent tests.

some semi-colons were inadvertently added/removed in mstring.js (my bad).
